### PR TITLE
Add access to trends and recommendations

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring.cloud.gateway.routes:
 - id: trends
   uri: lb://trends
   predicates:
-  - Path=/getCurrentHourAverages/**
+  - Path=/getCurrentHourAverages/**, /getHourlyAverageForAllStation/**, /getRecommendations/**
   filters:
   - AuthenticationGatewayFilter
 


### PR DESCRIPTION
Amending the path so frontend integration works.

You can now use Docker to run the backend and, once logged in on the frontend, access all three tabs (real time data, trends, recommendations) via the gateway. I have also modified the frontend to achieve this.